### PR TITLE
wrap component in factory, and call render instead of renderComponent

### DIFF
--- a/src/react_components/main.jsx
+++ b/src/react_components/main.jsx
@@ -4,9 +4,9 @@
   'use strict';
 
   var React   = require('react'),
-    Facebook = require('./facebook.jsx');
+    Facebook = React.createFactory(require('./facebook.jsx'));
 
-  React.renderComponent(
+  React.render(
     <Facebook />,
     document.getElementById('facebook')
   );


### PR DESCRIPTION
The initial version of the file called the Facebook component directly, so I wrapped it in a factory as suggested here: https://gist.github.com/sebmarkbage/ae327f2eda03bf165261

Deprecation warnings also came up for the call to `renderComponent`.