### PR TITLE
Add server tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,22 +1,32 @@
+extends: "eslint:recommended"
+
 env:
   node: true
   browser: true
 
 ecmaFeatures:
   jsx: true
+  blockBindings: true
+  classes: true
+  modules: true
 
 plugins:
   - react
 
 rules:
-  camelcase: 2
+  no-console: 0
+  camelcase: 1
+  new-cap: [0, { "capIsNew": true }]
   eol-last: 2
   quotes: [2, "single", "avoid-escape"]
   no-mixed-spaces-and-tabs: 2
+  no-extra-semi: 2
+  no-else-return: 1
   no-trailing-spaces: 2
-  no-underscore-dangle: 0
-  no-unused-vars: [1, { "args": "none" }]
-  vars-on-top: 1
+  no-unused-vars: [1, {"args": "none"}]
+  semi: 2
+  semi-spacing: 2
+  brace-style: [2, "1tbs", { "allowSingleLine": true }]
   react/jsx-boolean-value: 1
   react/jsx-quotes: [2, "double", "avoid-escape"]
   react/jsx-no-undef: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
-
+  - '0.12'
+before_script:
+  - npm run lint
 sudo: false

--- a/__tests__/facebook.js
+++ b/__tests__/facebook.js
@@ -1,4 +1,4 @@
-// __tests__/test.js
+// __tests__/facebook.js
 
 jest.dontMock('../src/react_components/facebook');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mullet",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Mullet Stack: Facebook in the front. Walmart in the back. (React.js/Hapi)",
   "main": "walmart.js",
   "scripts": {
@@ -49,7 +49,9 @@
     "jest-cli": "^0.4.15"
   },
   "jest": {
-    "unmockedModulePathPatterns": ["react"],
+    "unmockedModulePathPatterns": [
+      "react"
+    ],
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
     "testFileExtensions": [
       "es6",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "main": "walmart.js",
   "scripts": {
     "browserify": "browserify src/react_components/main.js > public/js/app.built.js",
-    "test": "jest",
+    "test": "jest && lab -v -l",
     "lint": "eslint src/react_components/main.js",
     "watch": "npm-watch",
     "start": "node walmart.js",
     "postinstall": "mkdir -p public/js && cp node_modules/bootstrap/dist/js/bootstrap.min.js node_modules/jquery/dist/jquery.min.* public/js && cp node_modules/bootstrap/dist/css/bootstrap*.min.css public/css && npm run browserify"
   },
   "engines": {
-    "node": "^0.10"
+    "node": "^0.12"
   },
   "repository": {
     "type": "git",
@@ -35,19 +35,24 @@
     "babel": "^5.8.23",
     "babel-jest": "^5.3.0",
     "babelify": "^6.3.0",
+    "blipp": "^2.3.0",
     "body-parser": "^1.14.1",
     "bootstrap": "^3.3.5",
     "browserify": "^11.2.0",
+    "h2o2": "^4.0.2",
     "hapi": "^9.3.1",
-    "inert": "^3.1.0",
+    "inert": "^3.2.0",
     "jquery": "^2.1.4",
     "npm-watch": "^0.0.1",
-    "react": "^0.13.3"
+    "react": "^0.13.3",
+    "vision": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^1.6.0",
     "eslint-plugin-react": "^3.5.1",
-    "jest-cli": "^0.4.19"
+    "jest-cli": "^0.4.19",
+    "code": "^1.5.0",
+    "lab": "^5.15.2"
   },
   "jest": {
     "unmockedModulePathPatterns": [

--- a/test/hapi-routes.js
+++ b/test/hapi-routes.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var Code = require('code'); // Hapi assertion library
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var server = require('../walmart');
+
+lab.experiment('General Endpoint Tests', function() {
+
+  lab.test('GET / (default test)', function (done) {
+    var options = {
+        method: 'GET',
+        url: '/'
+    };
+    server.inject(options, function(response) {
+      Code.expect(response.statusCode).to.equal(200);
+      done();
+    });
+  });
+
+  lab.test('GET /images/mullet_600.png', function (done) {
+    var options = {
+        method: 'GET',
+        url: '/images/mullet_600.png'
+    };
+    server.inject(options, function(response) {
+      Code.expect(response.statusCode).to.equal(200);
+      done();
+    });
+  });
+
+  lab.test('GET /data', function (done) {
+    var options = {
+        method: 'GET',
+        url: '/data'
+    };
+    server.inject(options, function(response) {
+      Code.expect(response.statusCode).to.equal(200);
+      Code.expect(response.result).to.be.an.object();
+      Code.expect(response.result.message).to.equal('Welcome to Mullet!');
+      done();
+    });
+  });
+});

--- a/walmart.js
+++ b/walmart.js
@@ -1,13 +1,23 @@
 var Hapi = require('hapi');
-var Inert = require('inert');
+var pkg = require('./package.json');
 
 // Create the Walmart Labs Hapi Server
 var PORT = process.env.PORT || 8000;
 var server = new Hapi.Server();
 
-server.register(Inert, function() {
+// Useful Hapi plugins
+// To generate documentation, use the hapi-swagger plugin
+var plugins = [
+  require('h2o2'),
+  require('inert'),
+  require('vision'),
+  require('blipp')
+];
+
+server.register(plugins, function() {
   server.connection({ port: PORT });
 
+  // Serve up all static content in public folder
   server.route({
     method: 'GET',
     path: '/{path*}',
@@ -20,8 +30,24 @@ server.register(Inert, function() {
     }
   });
 
+  // Serve up some sample JSON data
+  server.route({
+    method: 'GET',
+    path: '/data',
+    handler: function (request, reply) {
+      reply({
+        name: pkg.name,
+        version: pkg.version,
+        message: 'Welcome to Mullet!'
+      });
+    }
+  });
+
   // Start your Mullet Server
   server.start(function () {
     console.log('The Mullet Stack is running on port:', PORT);
   });
 });
+
+// For server inject in Lab tests
+module.exports = server;


### PR DESCRIPTION
* Added some additional useful Hapi plugins
* Added a sample JSON data route
* Added tests for `walmart.js` using hapijs/lab
* Travis-CI will now run `npm lint`